### PR TITLE
fix: lengthen timeouts for test timeouts

### DIFF
--- a/tests/squarespace.spec.ts
+++ b/tests/squarespace.spec.ts
@@ -40,6 +40,8 @@ test.beforeAll(async () => {
 test('posts nytimes bee clues to squarespace', async ({ page }, testInfo) => {
     // Because networking on github runners is 💩
     test.slow()
+    console.log('Setting default test timeout to 60000 ms')
+    test.setTimeout(60000)
 
     const postTitle = utils.getPostTitle()
     const clues = await utils.getCluesAsJson(page)


### PR DESCRIPTION
# What this pr does 
- Overrides the default test timeout and explicitly sets it to 60000 ms
- Not doing ☝🏽 resulted in the spec failing while the explicitly set long timeout inside the login function had not yet timeout 😡
- This was tested, using `Network.emulateNetworkConditions set to very slow throttling 

### Example
```javascript
// Slow down by a factor of 15
await utils.slowDown(15, page)

// Now login 
await utils.login() 
```